### PR TITLE
Use a custom esm cache for coverage testing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add additional tests.
 
 ### Fixed
-- Use a custom esm cache for coverage testing.
+- Disable esm cache for coverage testing.
 
 ## 1.2.0 - 2021-11-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Add additional tests.
 
+### Fixed
+- Use a custom esm cache for coverage testing.
+
 ## 1.2.0 - 2021-11-29
 
 ### Added

--- a/test/package.json
+++ b/test/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "test": "node --preserve-symlinks test.js test",
-    "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
-    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm test",
+    "coverage": "cross-env NODE_ENV=test ESM_OPTIONS='{cache:\"node_modules/.cache/esm-coverage\"}' nyc --reporter=lcov --reporter=text-summary npm test",
+    "coverage-ci": "cross-env NODE_ENV=test ESM_OPTIONS='{cache:\"node_modules/.cache/esm-coverage\"}' nyc --reporter=lcovonly npm test",
     "coverage-report": "nyc report"
   },
   "dependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "node --preserve-symlinks test.js test",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
-    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcov npm test",
+    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm test",
     "coverage-report": "nyc report"
   },
   "dependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "test": "node --preserve-symlinks test.js test",
-    "coverage": "cross-env NODE_ENV=test ESM_OPTIONS='{cache:\"node_modules/.cache/esm-coverage\"}' nyc --reporter=lcov --reporter=text-summary npm test",
-    "coverage-ci": "cross-env NODE_ENV=test ESM_OPTIONS='{cache:\"node_modules/.cache/esm-coverage\"}' nyc --reporter=lcovonly npm test",
+    "coverage": "cross-env NODE_ENV=test ESM_OPTIONS='{cache:false}' nyc --reporter=lcov --reporter=text-summary npm test",
+    "coverage-ci": "cross-env NODE_ENV=test ESM_OPTIONS='{cache:false}' nyc --reporter=lcovonly npm test",
     "coverage-report": "nyc report"
   },
   "dependencies": {


### PR DESCRIPTION
This replaces https://github.com/digitalbazaar/bedrock-meter/pull/4 as a way to fix coverage testing. `c8` may still be an option, but this patch is to fix the underlying `esm` issue.

This fix sets a custom `esm` cache directory when running coverage testing. Without a fix like this, mixed running of regular testing and coverage testing can result in incorrect coverage results.

This pattern may end up applying to many other packages. Please test and suggest improvements.