### PR TITLE
Switch from require to import for bnid in tests.

### DIFF
--- a/test/mocha/10-meters.js
+++ b/test/mocha/10-meters.js
@@ -1,16 +1,14 @@
 /*!
  * Copyright (c) 2021-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {createRequire} from 'node:module';
 import delay from 'delay';
 import {meters} from '@bedrock/meter';
-const require = createRequire(import.meta.url);
-const bnid = require('bnid');
+import {generateId} from 'bnid';
 
 describe('meters', () => {
   describe('insert', () => {
     it('insert', async () => {
-      const meter = {id: await bnid.generateId()};
+      const meter = {id: await generateId()};
       const record = await meters.insert({meter});
       should.exist(record);
     });
@@ -39,7 +37,7 @@ describe('meters', () => {
   describe('get', () => {
     it('get', async () => {
       // insert - get - check
-      const meter = {id: await bnid.generateId()};
+      const meter = {id: await generateId()};
       const _insert = await meters.insert({meter});
       const _get = await meters.get({id: _insert.meter.id});
       should.exist(_get);
@@ -50,7 +48,7 @@ describe('meters', () => {
   describe('update', () => {
     it('update - none', async () => {
       // insert - get - update - get
-      const meter = {id: await bnid.generateId()};
+      const meter = {id: await generateId()};
       const _insert = await meters.insert({meter});
       const _get = await meters.get({id: _insert.meter.id});
       should.exist(_get);
@@ -68,7 +66,7 @@ describe('meters', () => {
     });
     it('update - controller', async () => {
       // insert - get - update - get
-      const meter = {id: await bnid.generateId()};
+      const meter = {id: await generateId()};
       const _insert = await meters.insert({meter});
       const _get = await meters.get({id: _insert.meter.id});
       should.exist(_get);
@@ -112,7 +110,7 @@ describe('meters', () => {
   describe('remove', () => {
     it('check removed', async () => {
       // insert - get - remove - get
-      const meter = {id: await bnid.generateId()};
+      const meter = {id: await generateId()};
       const _insert = await meters.insert({meter});
       const _get = await meters.get({id: _insert.meter.id});
       should.exist(_get);

--- a/test/mocha/30-database.js
+++ b/test/mocha/30-database.js
@@ -3,18 +3,15 @@
  */
 import {meters} from '@bedrock/meter';
 import {cleanDB} from './helpers.js';
-import {createRequire} from 'node:module';
-const require = createRequire(import.meta.url);
-const bnid = require('bnid');
+import {generateId} from 'bnid';
 
 describe('Meters Database Tests', function() {
   let meter1;
   describe('Indexes', function() {
     beforeEach(async () => {
       await cleanDB();
-      meter1 = {id: await bnid.generateId()};
-      const meter2 = {id: await bnid.generateId()};
-
+      meter1 = {id: await generateId()};
+      const meter2 = {id: await generateId()};
       // mutliple records are inserted here in order to do proper assertions
       // for 'nReturned', 'totalKeysExamined' and 'totalDocsExamined'.
       await meters.insert({meter: meter1});


### PR DESCRIPTION
Removes the last `createRequire` stuff from the test project.
The test project should now be running. Previously was throwing an esm error when trying to `require` `bnid`