### PR TITLE
Change `return` to `continue` when getting a duplicate error adding  …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-meter ChangeLog
 
+## 5.2.1 - 2023-08-xx
+
+### Fixed
+- Change `return` to `continue` when getting a duplicate error adding
+  mock meters.
+
 ## 5.2.0 - 2023-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 - Change `return` to `continue` when getting a duplicate error adding
-  mock meters.
+  mock meters. Prior to this fix, some of the mock meters may not be
+  properly created.
 
 ## 5.2.0 - 2023-07-17
 

--- a/lib/mocks/dev-meters.js
+++ b/lib/mocks/dev-meters.js
@@ -35,7 +35,7 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     } catch(e) {
       if(e.name === 'DuplicateError') {
         // ignore duplicate error
-        return;
+        continue;
       }
 
       throw e;


### PR DESCRIPTION
… mock meters.